### PR TITLE
Added skeleton /translation/ endpoint for POST request

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -9,7 +9,8 @@ A Korean Name Pronounciation Service API. Currently supported for Korean names o
 ```bash
 $ python main.py
 ```
-Navigate to `localhost:8000` in your browser to see the magic!
+- Navigate to `localhost:8000` in your browser to see the magic!
+- To view API documention and try out endpoints, navigate to `localhost:8000/docs`
 
 ## Developer Environment Setup
 1. Ensure you're on a unix-like operating system (MacOS, Ubuntu, etc.)

--- a/api/data_models/name_translation.py
+++ b/api/data_models/name_translation.py
@@ -1,0 +1,6 @@
+from pydantic import BaseModel
+
+class KoreanName(BaseModel):
+    romanized_english: str
+    korean_parallel: str | None = None
+    

--- a/api/main.py
+++ b/api/main.py
@@ -1,12 +1,37 @@
 import uvicorn
 from fastapi import FastAPI
+from data_models.name_translation import KoreanName
 
 app = FastAPI()
 
 @app.get("/")
-async def root():
+async def root() -> dict:
+    """Function to handle root endpoint for API.
+    Current behavior returns 'Hello World' string.
+
+    Returns:
+        dict: JSON response payload as dictionary
+    """
     return { 
         "message": "Hello World" 
+    }
+
+@app.post("/translation/")
+async def translate(name:KoreanName) -> dict:
+    """Function to handle /translation POST request endpoint
+
+    Args:
+        name (KoreanName): name with english romanization and korean parallel
+
+    Returns:
+        dict: JSON response payload as dictionary
+    """
+    print(f"/translation/ called with POST Request Body:\n{' '*4}{name}")
+    ## TODO: Add code below to take in name and return a pronounciation string
+
+
+    return {
+        "message": f"POST Request for { name.romanized_english } received"
     }
 
 if __name__ == "__main__":


### PR DESCRIPTION
1.  Added initial skeleton for /translation POST request endpoint. This endpoint expects a JSON payload with the following structure
```
{
    "english_romanized": <korean name romanized in english> (required*)
    "korean_parallel": <korean name parallel to english_romanized but in korean> (optional)
}
```
2. Updating documentation with instructions on how to navigate to fastapi `/docs`